### PR TITLE
front/design/#28 4개 페이지 기초 디자인 레이아웃 작업/ 로고,제목 등 일부 컴포넌트 수정

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+import Logo from './Logo';
+import Name from './Name';
+import SignBtn from './SignBtn';
+
+function ChooseFramePage() {
+  return (
+    <div>
+      <Container>
+        <LogoWrap>
+          <Logo />
+          <Name />
+        </LogoWrap>
+        <BtnWrap>
+          <SignBtn>로그아웃</SignBtn>
+        </BtnWrap>
+      </Container>
+    </div>
+  );
+}
+
+export default ChooseFramePage;
+const Container = styled.div`
+  display: flex;
+  margin-top: 3rem;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const LogoWrap = styled.div`
+  display: flex;
+`;
+
+const BtnWrap = styled.div``;

--- a/frontend/src/components/Logo.jsx
+++ b/frontend/src/components/Logo.jsx
@@ -5,10 +5,8 @@ const LogoStyle = styled.div`
   width: 55px;
   height: 54px;
   flex-shrink: 0;
-  border-radius: 10px;s
-  background:
-    url(${logoImage}),
-    lightgray 50% / cover no-repeat;
+  border-radius: 10px;
+  background: url(${logoImage}) lightgray 50% / cover no-repeat;
 `;
 
 function Logo() {

--- a/frontend/src/components/Name.jsx
+++ b/frontend/src/components/Name.jsx
@@ -5,8 +5,8 @@ const NameStyle = styled.div`
   width: 290px;
   height: 50px;
   flex-shrink: 0;
-  background-image: url(${logoText});
-  background-size: cover;
+  background: url(${logoText}) lightgray 50% / cover no-repeat;
+  background-color: ${(props) => props.theme.backgroundColor};
 `;
 
 function Name() {

--- a/frontend/src/components/SignBtn.jsx
+++ b/frontend/src/components/SignBtn.jsx
@@ -15,7 +15,6 @@ export default styled.button`
   border: none;
 
   color: #000;
-  font-family: Do Hyeon;
   font-size: 16px;
   font-style: normal;
   font-weight: 400;

--- a/frontend/src/components/Title.jsx
+++ b/frontend/src/components/Title.jsx
@@ -3,13 +3,10 @@ import { styled } from 'styled-components';
 export default styled.h1`
   width: 976px;
   height: 111px;
-  flex-direction: column;
   flex-shrink: 0;
-
-  color: #7a6c79;
+  color: #3f3d3f;
   text-align: center;
-  font-family: Do Hyeon;
-  font-size: 5rem;
+  font-size: 80px;
   font-style: normal;
   font-weight: 400;
   line-height: normal;

--- a/frontend/src/pages/ChooseFramePage.jsx
+++ b/frontend/src/pages/ChooseFramePage.jsx
@@ -1,7 +1,68 @@
-import React from 'react';
+import { React } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import Header from '../components/Header';
+import Title from '../components/Title';
+import PageShiftBtn from '../components/PageShiftBtn';
 
 function ChooseFramePage() {
-  return <div>프레임 선택</div>;
+  const navigate = useNavigate();
+
+  const handlePageShift = () => {
+    navigate('/upload');
+  };
+
+  return (
+    <div>
+      <Container>
+        <MainWrap>
+          <Header />
+          <TitleWrap>
+            <Title>프레임 선택</Title>
+          </TitleWrap>
+          <ProgressBar>
+            프로그레스 바/프로그레스 바/프로그레스 바/프로그레스 바/프로그레스
+            바/프로그레스 바/프로그레스 바
+          </ProgressBar>
+          <PageShiftWrap>
+            <PageShiftBtn onClick={handlePageShift} />
+          </PageShiftWrap>
+        </MainWrap>
+      </Container>
+    </div>
+  );
 }
 
 export default ChooseFramePage;
+
+const Container = styled.div`
+  width: 100%;
+  min-height: 100vh;
+  background: ${(props) => props.theme.backgroundColor};
+`;
+
+const MainWrap = styled.div`
+  max-width: 1440px;
+  height: 100vh;
+  margin: 0 auto;
+  flex-shrink: 0;
+  border: 3px solid black;
+  align-items: center;
+`;
+
+const TitleWrap = styled.div`
+  margin-top: 3rem;
+  display: flex;
+  justify-content: center;
+`;
+
+const ProgressBar = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: 3rem;
+`;
+
+const PageShiftWrap = styled.div`
+  display: flex;
+  justify-content: center;
+`;

--- a/frontend/src/pages/ConvertAIPage.jsx
+++ b/frontend/src/pages/ConvertAIPage.jsx
@@ -1,7 +1,68 @@
-import React from 'react';
+import { React } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import Header from '../components/Header';
+import Title from '../components/Title';
+import PageShiftBtn from '../components/PageShiftBtn';
 
 function ConvertAIPage() {
-  return <div>AI 변환</div>;
+  const navigate = useNavigate();
+
+  const handlePageShift = () => {
+    navigate('/upload');
+  };
+
+  return (
+    <div>
+      <Container>
+        <MainWrap>
+          <Header />
+          <TitleWrap>
+            <Title>AI 변환</Title>
+          </TitleWrap>
+          <ProgressBar>
+            프로그레스 바/프로그레스 바/프로그레스 바/프로그레스 바/프로그레스
+            바/프로그레스 바/프로그레스 바
+          </ProgressBar>
+          <PageShiftWrap>
+            <PageShiftBtn onClick={handlePageShift} />
+          </PageShiftWrap>
+        </MainWrap>
+      </Container>
+    </div>
+  );
 }
 
 export default ConvertAIPage;
+
+const Container = styled.div`
+  width: 100%;
+  min-height: 100vh;
+  background: ${(props) => props.theme.backgroundColor};
+`;
+
+const MainWrap = styled.div`
+  max-width: 1440px;
+  height: 100vh;
+  margin: 0 auto;
+  flex-shrink: 0;
+  border: 3px solid black;
+  align-items: center;
+`;
+
+const TitleWrap = styled.div`
+  margin-top: 3rem;
+  display: flex;
+  justify-content: center;
+`;
+
+const ProgressBar = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: 3rem;
+`;
+
+const PageShiftWrap = styled.div`
+  display: flex;
+  justify-content: center;
+`;

--- a/frontend/src/pages/CustomizingPage.jsx
+++ b/frontend/src/pages/CustomizingPage.jsx
@@ -1,7 +1,68 @@
-import React from 'react';
+import { React } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import Header from '../components/Header';
+import Title from '../components/Title';
+import PageShiftBtn from '../components/PageShiftBtn';
 
 function CustomizingPage() {
-  return <div>커스터마이징</div>;
+  const navigate = useNavigate();
+
+  const handlePageShift = () => {
+    navigate('/upload');
+  };
+
+  return (
+    <div>
+      <Container>
+        <MainWrap>
+          <Header />
+          <TitleWrap>
+            <Title>커스터마이징</Title>
+          </TitleWrap>
+          <ProgressBar>
+            프로그레스 바/프로그레스 바/프로그레스 바/프로그레스 바/프로그레스
+            바/프로그레스 바/프로그레스 바
+          </ProgressBar>
+          <PageShiftWrap>
+            <PageShiftBtn onClick={handlePageShift} />
+          </PageShiftWrap>
+        </MainWrap>
+      </Container>
+    </div>
+  );
 }
 
 export default CustomizingPage;
+
+const Container = styled.div`
+  width: 100%;
+  min-height: 100vh;
+  background: ${(props) => props.theme.backgroundColor};
+`;
+
+const MainWrap = styled.div`
+  max-width: 1440px;
+  height: 100vh;
+  margin: 0 auto;
+  flex-shrink: 0;
+  border: 3px solid black;
+  align-items: center;
+`;
+
+const TitleWrap = styled.div`
+  margin-top: 3rem;
+  display: flex;
+  justify-content: center;
+`;
+
+const ProgressBar = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: 3rem;
+`;
+
+const PageShiftWrap = styled.div`
+  display: flex;
+  justify-content: center;
+`;

--- a/frontend/src/pages/UploadImagePage.jsx
+++ b/frontend/src/pages/UploadImagePage.jsx
@@ -1,7 +1,68 @@
-import React from 'react';
+import { React } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import Header from '../components/Header';
+import Title from '../components/Title';
+import PageShiftBtn from '../components/PageShiftBtn';
 
 function UploadImagePage() {
-  return <div>이미지 업로드</div>;
+  const navigate = useNavigate();
+
+  const handlePageShift = () => {
+    navigate('/upload');
+  };
+
+  return (
+    <div>
+      <Container>
+        <MainWrap>
+          <Header />
+          <TitleWrap>
+            <Title>이미지 업로드</Title>
+          </TitleWrap>
+          <ProgressBar>
+            프로그레스 바/프로그레스 바/프로그레스 바/프로그레스 바/프로그레스
+            바/프로그레스 바/프로그레스 바
+          </ProgressBar>
+          <PageShiftWrap>
+            <PageShiftBtn onClick={handlePageShift} />
+          </PageShiftWrap>
+        </MainWrap>
+      </Container>
+    </div>
+  );
 }
 
 export default UploadImagePage;
+
+const Container = styled.div`
+  width: 100%;
+  min-height: 100vh;
+  background: ${(props) => props.theme.backgroundColor};
+`;
+
+const MainWrap = styled.div`
+  max-width: 1440px;
+  height: 100vh;
+  margin: 0 auto;
+  flex-shrink: 0;
+  border: 3px solid black;
+  align-items: center;
+`;
+
+const TitleWrap = styled.div`
+  margin-top: 3rem;
+  display: flex;
+  justify-content: center;
+`;
+
+const ProgressBar = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: 3rem;
+`;
+
+const PageShiftWrap = styled.div`
+  display: flex;
+  justify-content: center;
+`;


### PR DESCRIPTION
개요 :

4개 페이지 기초 디자인 레이아웃 작업/ 로고,제목 등 일부 컴포넌트 수정


설명 :

- 프레임선택 / 이미지업로드 / AI 변환 / 커스터마이징 페이지 기초 디자인 레이아웃 작업
- Logo.jsx / Name.jsx / SignBtn.jsx / Title.jsx 4개 컴포넌트 css 일부 수정
- Header.jsx 컴포넌트 생성  -> Logo.jsx / Name.jsx / SignBtn.jsx 하나로 합침

결과 :

<img width="770" alt="스크린샷 2023-07-13 오후 3 01 19" src="https://github.com/2023SB-TeamJ/2023SB-Team-J/assets/83015089/fc1ad0e7-cd2a-4c75-b59e-8450b6732f02">
