### PR TITLE
[front/fix/#112] 이미지 업로드 시 간헐적으로 500에러 임시해결

### DIFF
--- a/backend/backend_project/settings.py
+++ b/backend/backend_project/settings.py
@@ -13,7 +13,6 @@ secret_file = os.path.join(BASE_DIR, "secrets.json")
 with open(secret_file) as f:
     secrets = json.loads(f.read())
 
-
 def get_secret(setting):
     """비밀 변수를 가져오거나 명시적 예외를 반환한다."""
     try:

--- a/backend/image/s3_utils.py
+++ b/backend/image/s3_utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import threading
 
 import boto3
 from backend_project.settings import *
@@ -6,13 +7,15 @@ import requests
 from io import BytesIO
 from PIL import Image
 
+lock = threading.Lock()
 
 def upload_image_to_s3(img_file, key, ExtraArgs):
-    s3 = boto3.client(
-        "s3",
-        aws_access_key_id=AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=AWS_SECRET_ACCESS_KEY
-    )
+    with lock:
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id=AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=AWS_SECRET_ACCESS_KEY
+        )
     bucket_name = "t4y-bucket"
     s3.upload_fileobj(img_file, bucket_name, key, ExtraArgs)
     img_url = f"https://{bucket_name}.s3.amazonaws.com/{key}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - 3306:3306
     networks:
-      - t4yd
+      - t4y
 
   backend:
     build:

--- a/frontend/src/pages/UploadImagePage.jsx
+++ b/frontend/src/pages/UploadImagePage.jsx
@@ -21,6 +21,8 @@ function UploadImagePage() {
     setFiles((prevFiles) => [...prevFiles, file]);
   };
 
+  console.log(files);
+
   const uploadAllImages = async () => {
     const userId = 1;
 
@@ -28,6 +30,9 @@ function UploadImagePage() {
       const formData = new FormData();
       formData.append('id', userId);
       formData.append('image', file);
+      Array.from(formData.entries()).forEach((pair) => {
+        console.log(`${pair[0]}, ${pair[1]}`);
+      });
 
       return axios
         .post('http://localhost:8000/api/v1/frame/', formData, {


### PR DESCRIPTION
개요 :

- 이미지 업로드 시 간헐적으로 500에러가 뜸
- GPT가 알려준 코드로 임시해결했으나 오류가 뜨면 또 fix 할 예정

설명 :

오류 코드)
ERROR
Request failed with status code 500
AxiosError: Request failed with status code 500
    at settle (http://localhost:3000/static/js/bundle.js:72153:12)
    at XMLHttpRequest.onloadend (http://localhost:3000/static/js/bundle.js:70853:66)

KeyError: 'default_config_resolver'
[25/Jul/2023 23:14:01] "POST /api/v1/frame/ HTTP/1.1" 500 124270
[25/Jul/2023 23:14:03] "POST /api/v1/frame/ HTTP/1.1" 201 116
[25/Jul/2023 23:14:03] "POST /api/v1/frame/ HTTP/1.1" 201 116
[25/Jul/2023 23:14:03] "POST /api/v1/frame/ HTTP/1.1" 201 116

결과 :

<img width="523" alt="image" src="https://github.com/2023SB-TeamJ/2023SB-Team-J/assets/100352367/4b972cdf-d448-4bb7-9351-8d461501aa41">